### PR TITLE
Remove unnecessary new lines between tags/attributes

### DIFF
--- a/openxava/src/main/java/org/openxava/web/taglib/LinkTag.java
+++ b/openxava/src/main/java/org/openxava/web/taglib/LinkTag.java
@@ -42,13 +42,13 @@ public class LinkTag extends ActionTagBase implements IActionTag {
 						 		
 			pageContext.getOut().print("<input name='");
 			pageContext.getOut().print(Ids.decorate(application, module, "action." + getAction())); 
-			pageContext.getOut().println("' type='hidden'/>\n");
+			pageContext.getOut().print("' type='hidden'/>");
 			
 			pageContext.getOut().print("<a ");
 			if (Is.emptyString(getArgv())) { 
 				pageContext.getOut().print("id='");
 				pageContext.getOut().print(Ids.decorate(application, module, getAction())); 
-				pageContext.getOut().println("'");
+				pageContext.getOut().print("'");
 			}
 			if (!Is.emptyString(getCssClass())) {
 				pageContext.getOut().print(" class='");

--- a/openxava/src/main/resources/i18n/Messages_es.properties
+++ b/openxava/src/main/resources/i18n/Messages_es.properties
@@ -904,7 +904,6 @@ organization_created=creada y accesible en
 executing_on_database=Ejecutando en base de datos {0}: {1}
 organization_deleted=Organización borrada
 organization_name_missing=Nombre de organización no especificado
-filter_parameter_numeric=Imposible filtrar los datos: {0} ha de ser numérico
 customize_list=Personalizar lista
 remove_column=Quitar columna
 impossible_store_column_movement=Imposible almacenar el movimiento de la columna


### PR DESCRIPTION
Remove unnecessary new lines between tags/attributes that sometimes cause unwanted blank spaces in view.

E.g.: below and to the right of every entity list: "There are xyz records in list ( Hide them)". The space before "Hide".