### PR TITLE
Fix: List View Filter is not working after rearranging column

### DIFF
--- a/openxava/src/main/java/org/openxava/actions/TabRefreshAction.java
+++ b/openxava/src/main/java/org/openxava/actions/TabRefreshAction.java
@@ -1,0 +1,43 @@
+package org.openxava.actions;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TabRefreshAction extends ViewBaseAction implements ICustomViewAction {
+
+    String tabObject;
+
+    String customView;
+
+    @Override
+    public void execute() throws Exception {
+        org.openxava.tab.Tab tab;
+        try {
+            tab = (org.openxava.tab.Tab) getContext().get(getRequest(), tabObject);
+        } catch (Exception e) {
+            String [] id = tabObject.split("_+");
+            String application = id[1];
+            String module = id[2];
+            StringBuffer collectionSB = new StringBuffer();
+            for (int i=3; i<id.length; i++) { // To work with collections inside @AsEmbedded references
+                if (i > 3) collectionSB.append("_");
+                collectionSB.append(id[i]);
+            }
+            String collection = collectionSB.toString();
+            String tabObject = "list".equals(collection)?"xava_tab":"xava_collectionTab_" + collection;
+            tab = (org.openxava.tab.Tab) getContext().get(application, module, tabObject);
+        }
+        if (tab.getCollectionView() != null) {
+            tab.getCollectionView().setMustRefreshCollection(true);
+        }else {
+            customView = ICustomViewAction.DEFAULT_VIEW;
+        }
+    }
+
+    @Override
+    public String getCustomView() throws Exception {
+        return customView;
+    }
+}

--- a/openxava/src/main/java/org/openxava/view/View.java
+++ b/openxava/src/main/java/org/openxava/view/View.java
@@ -6997,4 +6997,8 @@ public class View implements java.io.Serializable {
 		return descriptionsList.getCondition();
 	}
 
+	public void setMustRefreshCollection(Boolean mustRefreshCollection) {
+		this.mustRefreshCollection = mustRefreshCollection;
+	}
+
 }

--- a/openxava/src/main/resources/META-INF/resources/xava/js/openxava.js
+++ b/openxava/src/main/resources/META-INF/resources/xava/js/openxava.js
@@ -452,7 +452,9 @@ openxava.initLists = function(application, module) {
 	    stop: function( event, ui ) {
 	    	ui.item.css("width", "");
 	    	var tableId = $(event.target).closest("table").attr("id"); 
-	    	Tab.moveProperty(tableId, ui.item.startPos - 2, ui.item.index() - 2);
+	    	Tab.moveProperty(tableId, ui.item.startPos - 2, ui.item.index() - 2, () => {
+				openxava.executeAction(application, module, '', false, 'TabRefreshController.tabRefreshAction', 'tabObject=' + tableId)
+			});
 	    }
 	});
 	$('.xava_sortable_row').sortable({ 
@@ -737,7 +739,9 @@ openxava.removeColumn = function(application, module, columnId, tabObject) {
 	th.fadeOut();
     $(table).find("td:nth-child(" + i + ")").fadeOut();
 	var property = $("#" + columnId).closest("th").attr("data-property");
-	Tab.removeProperty(application, module, property, tabObject);
+	Tab.removeProperty(application, module, property, tabObject, () => {
+		openxava.executeAction(application, module, '', false, 'TabRefreshController.tabRefreshAction', 'tabObject=' + tabObject)
+	});
 }
 
 openxava.setPageRowCount = function(application, module, collection, select) {	

--- a/openxava/src/main/resources/xava/default-controllers.xml
+++ b/openxava/src/main/resources/xava/default-controllers.xml
@@ -850,5 +850,10 @@ here that you want to override.
 			<set property="subscribe" value="false" />	
 		</action>	
 	</controller>
+
+	<controller name="TabRefreshController">
+		<action name="tabRefreshAction"
+				class="org.openxava.actions.TabRefreshAction"/>
+	</controller>
 	
 </controllers>


### PR DESCRIPTION
Fixes for:

1. During customization, after removing a column if we move the last column of the tab to another position, an Error alert is displayed in UI.
2. When a column is moved in the tab view of an Entity/Collection using list customization. The filter is not working for the moved columns.