### PR TITLE
Fix: Ugly square border in collection tables on Firefox.

### DIFF
--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,9 @@
 Change Log for OpenXava project
 ===============================
 
+- Fix: Ugly square border in collection tables on Firefox.
+- Fix: "Unable to rename class file from" error when starting Tomcat occasionally with OpenXava Studio JDK.
+
 OpenXava 7.5 (2025-3-21)
 ------------------------
 - Hot code reloading for development including entities, actions, controllers, modules, annotations, etc.

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -775,7 +775,11 @@ input[type="radio"] {
 }
 
 .ox-frame .ox-list { 
-	border: 2px solid;
+	border: 2px solid var(--list-background);
+}
+
+.firefox .ox-frame .ox-list { 
+	border-collapse: separate;
 }
 
 .ox-list-subheader input[type="text"] { 

--- a/openxava/src/main/resources/hotswap-agent.properties
+++ b/openxava/src/main/resources/hotswap-agent.properties
@@ -1,8 +1,12 @@
 pluginPackages=org.openxava.hotswap
 autoHotswap=true
 
+# To avoid "Unable to rename class file from" starting Tomcat
+excludedClassLoaderPatterns=org.apache.jsp.*
+
 # disabledPlugins and LOGGER are already configured JDK of OpenXava Studio 7 R4, 
 # but we keep here too for the case you use another JDK with HotswapAgent enabled
 disabledPlugins=Hibernate, Hibernate3JPA, Hibernate3, Spring, Jersey1, Jersey2, Jetty, Tomcat, ZK, Logback, Log4j2, MyFaces, Mojarra, Omnifaces, ELResolver, WildFlyELResolver, OsgiEquinox, Owb, Proxy, WebObjects, Weld, JBossModules, ResteasyRegistry, Deltaspike, GlassFish, Vaadin, Wicket, CxfJAXRS, FreeMarker, Undertow, MyBatis
 LOGGER=error
 LOGGER.org.hotswap.agent.watch.nio.TreeWatcherNIO=error
+


### PR DESCRIPTION
- Fix: Fix: Ugly square border in collection tables on Firefox.
- Fix: "Unable to rename class file from" error when starting Tomcat occasionally with OpenXava Studio JDK.