### PR TITLE
Fix: Small square corner appearing behind the rounded corner on top of

### DIFF
--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,7 @@
 Change Log for OpenXava project
 ===============================
 
+- Fix: Small square corner appearing behind the rounded corner on top of dialogs.
 - All Java code of openxavatest project converted to UTF-8 encoding.
 - Fix: Frame for @LargeDisplay properties is too close to the above frame, touching it.
 - Fix: Row actions are misaligned when an IAvailableAction is not displayed in some rows.

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -1864,7 +1864,8 @@ td.ox-list-subheader > div {
 .ui-dialog-titlebar {
 	font-size: 1.2em;
 	color: var(--dialog-titlebar-color) !important;
-	background: var(--dialog-titlebar-background) !important;  
+	background: var(--dialog-titlebar-background) !important;
+	border-radius: 24px;  
 }
 
 .ui-dialog-titlebar button {


### PR DESCRIPTION
dialogs