### PR TITLE
Fix: Odd characters and incorrect attribute values in XML files of

### DIFF
--- a/openxava-project-management-archetype-spanish/src/main/resources/xava/aplicacion.xml
+++ b/openxava-project-management-archetype-spanish/src/main/resources/xava/aplicacion.xml
@@ -5,7 +5,7 @@
 <aplicacion nombre="tuaplicacion"> 
 	
 	<!--
-	Un mï¿½dulo por defecto se asume para cada
+	Un módulo por defecto se asume para cada
 	controlador en <modulo-defecto/> 
 	-->
 	<modulo-defecto>		  
@@ -13,7 +13,7 @@
 	</modulo-defecto>
 	
 	<!--
-	Podemos definir mï¿½dulos adicionales, por ejemplo: 	
+	Podemos definir módulos adicionales, por ejemplo: 	
 	<modulo nombre="ProfesorSoloLectura">
 		<modelo nombre="Profesor"/>
 		<controlador nombre="Print"/>

--- a/openxava-project-management-archetype-spanish/src/main/resources/xava/controladores.xml
+++ b/openxava-project-management-archetype-spanish/src/main/resources/xava/controladores.xml
@@ -3,13 +3,13 @@
 <!DOCTYPE controladores SYSTEM "dtds/controladores.dtd">
 
 <!-- 
-Documentaciï¿½n sobre controladores: 
+Documentación sobre controladores: 
 https://www.openxava.org/OpenXavaDoc/docs/controllers_es.html
 
 Controladores por defecto, incluidos en OpenXava (puedes extender de ellos):
 https://github.com/openxava/openxava/blob/master/openxava/src/main/resources/xava/default-controllers.xml
  
-Ejemplos de controladores (de la aplicaciï¿½n de pruebas):
+Ejemplos de controladores (de la aplicación de pruebas):
 https://github.com/openxava/openxava/blob/master/openxavatest/src/main/resources/xava/controllers.xml
 -->
 
@@ -19,7 +19,7 @@ https://github.com/openxava/openxava/blob/master/openxavatest/src/main/resources
     <var-entorno nombre="tuaplicacion_ANYO_DEFECTO" valor="2015"/>
     -->
     
-    <!-- Objeto de sesiï¿½n:
+    <!-- Objeto de sesión:
     <Objeto nombre="tuaplicacion_anyoActivo" clase="java.lang.Integer" valor="2015" 
             ambito="global"/>
     -->
@@ -51,7 +51,7 @@ https://github.com/openxava/openxava/blob/master/openxavatest/src/main/resources
 		</accion>
 		
 		<accion nombre="save" modo="detail"
-			por-defecto="si-es-posible"
+			por-defecto="si-posible"
 			clase="com.tuempresa.tuaplicacion.acciones.GuardarVolviendoALista"
 			imagen="save.gif"
 			icono="content-save"

--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,8 @@
 Change Log for OpenXava project
 ===============================
 
+- Fix: Odd characters and incorrect attribute values in XML files of Project Management Spanish archetype.
+
 OpenXava 7.5.1 (2025-5-2)
 -------------------------
 - New look & feel for column customization icons when column resizing is enabled.


### PR DESCRIPTION
Project Management Spanish archetype