### PR TITLE
Fix: java.util.Date with @DateTime or @Stereotype("DATETIME") formats

### DIFF
--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,7 @@
 Change Log for OpenXava project
 ===============================
 
+- Fix: java.util.Date with @DateTime or @Stereotype("DATETIME") formats wrong in Chinese with Java 21.
 - Fix: Unable sometimes to parse LocalTime in English with Java 21 depending on the server locale.
 - Fix: Incorrect format sometimes for LocalTime in Chinese with Java 21 depending on the server locale.
 - Fix: LocalTime in Chinese corrupts the data on focus lost.

--- a/openxava/src/main/java/org/openxava/formatters/DateTimeCombinedFormatter.java
+++ b/openxava/src/main/java/org/openxava/formatters/DateTimeCombinedFormatter.java
@@ -24,7 +24,7 @@ public class DateTimeCombinedFormatter extends DateTimeBaseFormatter implements 
 		if (date == null) return "";
 		if (date instanceof String || date instanceof Number) return date.toString();
 		if (Dates.getYear((java.util.Date)date) < 2) return "";
-		if (isZhFormatAndJavaIs21orBetter()) return getDateTimeFormat(false).format(date).replace("p. m.", "PM").replace("a. m.", "AM"); //use java 17 blank space \u00a0
+		if (isZhFormatAndJavaIs21orBetter()) return getDateTimeFormat(false).format(date).replace("p.\u00a0m.", "PM").replace("a.\u00a0m.", "AM"); //use java 17 blank space \u00a0
 		return getDateTimeFormat(false).format(date); 
 	}
 
@@ -33,7 +33,7 @@ public class DateTimeCombinedFormatter extends DateTimeBaseFormatter implements 
 		if (string.indexOf('-') >= 0 && !isDashFormat()) { // SimpleDateFormat does not work well with -
 			string = Strings.change(string, "-", "/");
 		}
-		if (isZhFormatAndJavaIs21orBetter()) string = string.replace("PM", "p. m.").replace("AM", "a. m.");
+		if (isZhFormatAndJavaIs21orBetter()) string = string.replace("PM", "p.\u00a0m.").replace("AM", "a.\u00a0m.");
 		DateFormat [] dateFormats = getDateTimeFormats();
 		for (int i=0; i<dateFormats.length; i++) {
 			try {

--- a/openxavatest/src/test/java/org/openxava/test/tests/byfeature/DateCalendarTest.java
+++ b/openxavatest/src/test/java/org/openxava/test/tests/byfeature/DateCalendarTest.java
@@ -4,8 +4,8 @@ import java.util.*;
 
 import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.*;
+
 /**
- * 
  * To test pop up calendar with Selenium.
  * 
  * @author Chungyen Tsai
@@ -55,7 +55,8 @@ public class DateCalendarTest extends WebDriverTestBase {
 		assertNoErrors();
 	}
 	
-	public void testLocalTimeAndLocalDateTimeSpanishUSA() throws Exception { 
+	public void testLocalTimeAndLocalDateTimeSpanishUSA() throws Exception {
+		// It fails with Java 8 and 21: https://openxava.org/xavaprojects/o/OpenXava/m/Issue?detail=ff8080819581a7c6019594d82bf10022
 		if (isWindows7()) setHeadless(false); // In Windows 7 with headless the language is not changed to "es-US" maybe because a bug of Chrome version in Windows 7
 		changeLanguage("es-US");
 		goModule("Event");
@@ -127,7 +128,7 @@ public class DateCalendarTest extends WebDriverTestBase {
 		execute("List.filter");
 		assertNoErrors(); 
 	}
-
+	
 	public void testChineseDateTimeInJava8AndAmIssue_formatDateAndDateTimeUsingTwoDigits_usingFourDigits() throws Exception { 
 		changeLanguage("zh-TW");
 		appointment2(); 
@@ -597,7 +598,7 @@ public class DateCalendarTest extends WebDriverTestBase {
 	private void appointment2() throws Exception {
 		goModule("Appointment2");
 		execute("List.viewDetail", "row=2");
-		assertValue("time", "2015/5/26 PM1:34"); // Fails with Java 21: https://openxava.org/xavaprojects/o/OpenXava/m/Issue?detail=ff8080819581a7c6019594cccba40021
+		assertValue("time", "2015/5/26 PM1:34"); 
 		assertValue("dateTime", "2015/5/26 PM2:34");
 		List<WebElement> calendarPopUp = getDriver().findElements(By.cssSelector("i.mdi.mdi-calendar-clock"));
 		calendarPopUp.get(1).click();


### PR DESCRIPTION
wrong in Chinese with Java 21