### PR TITLE
Fix: Date icon is displaced in date fields on Firefox when flowLayout is

### DIFF
--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,7 +1,7 @@
 Change Log for OpenXava project
 ===============================
 
-
+- Fix: Date icon is displaced in date fields on Firefox when flowLayout is enabled.
 - Fix: A frame placed just after a @Coordinates property is incorrectly put inside the @Coordinates frame.
 - Fix: A frame wraps the next sibling when flowLayout=true and plain properties follow a frame.
 - Fix: Frame stays on the same row as plain properties when the framed element is placed before them.

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -1192,7 +1192,6 @@ i.mdi {
 .ox-element-collection .mdi-open-in-new {  
 	vertical-align: middle;
 	padding: 4px 4px 4px 0px;
-	margin-right: -20px;
 }
 
 .mdi-delete:hover {

--- a/openxavatest/manual-tests/LayoutTest.txt
+++ b/openxavatest/manual-tests/LayoutTest.txt
@@ -24,6 +24,7 @@ With flowLayout=true in xava.properties:
 	Data 2 frame must be aligned with Remarks and Photos frames on right.
 - Product2: All properties well aligned, including the descriptionsLists.
 - Movie3WithSection: The @Files property is shown and fill all the section width.
+- Invoice with Firefox: Date icon inside textfield.
 - Invoice: In Amounts section the fields are in one row (when enough space), nicely aligned.	
 - CarrierWithCollectionsTogether: Collections frames aligned with Header frame on right.
 - Warehouse: Simple, one field below other.


### PR DESCRIPTION
enabled