### PR TITLE
Card format fixes

### DIFF
--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,8 @@
 Change Log for OpenXava project
 ===============================
 
+- Fix: Chat panel overlaps the rightmost cards in card-format list view.
+- Fix: In card-format, cards do not use all available space, leaving too much blank space on the right.
 - Fix: Misaligned totals in calculated, @ManyToMany, and @OrderColumn collections with several references.
 - Fix: Collection changes via chat are not immediately reflected in the UI.
 - Fix: Refresh action does not refresh collections.

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -2622,14 +2622,14 @@ div[id$="_Index__view"] .ox-list-title {
 }
 
 .ox-cards {
-	width: calc(100vw - 210px);  
-	display: inline-flex;
-	flex-wrap: wrap;
+	width: 100%;  
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
 	padding: 0px 5px 3px 5px;
+	box-sizing: border-box;
 }
 
 .ox-card {
-	flex: 0 1 330px;
 	margin: 6px;
 	padding: 10px 10px 5px 10px;
 	color: var(--card-color); 

--- a/openxavatest/manual-tests/CardsTest.txt
+++ b/openxavatest/manual-tests/CardsTest.txt
@@ -5,3 +5,10 @@ Module: Movie
 - The image is not shown at full size, but to a reasonable one.
 - The card with a link is not broken but has a correct layout.
 
+Module: Invoice
+- Change to Cards.
+- The card fill all the width with no blank space on right.
+- Open and close the chat panel. The panel does not hide the cards.
+- Resize the window. The cards fill all the width.
+- Card in latest row when alone is of the same size of the others.
+


### PR DESCRIPTION
- Fix: Chat panel overlaps the rightmost cards in card-format list view.
- Fix: In card-format, cards do not use all available space, leaving too much blank space on the right.