### PR TITLE
Documentation index reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,23 @@ Then start the application again.
 
 ## New project from other archetypes
 Apart from the basic archetype, there are other OpenXava archetypes, so you don't have to start your application from scratch.
+
+### Master-Detail
 For a project with an initial Master-Detail structure, use openxava-master-detail-archetype, in this way:
 
 	mvn archetype:generate -DarchetypeGroupId=org.openxava -DarchetypeArtifactId=openxava-master-detail-archetype -DarchetypeVersion=RELEASE -DgroupId=com.yourcompany -DartifactId=yourmasterdetail -DinteractiveMode=false
 	
+### CRM
 For a basic CRM use openxava-crm-archetype, thus:
 
 	mvn archetype:generate -DarchetypeGroupId=org.openxava -DarchetypeArtifactId=openxava-crm-archetype -DarchetypeVersion=RELEASE -DgroupId=com.yourcompany -DartifactId=yourcrm -DinteractiveMode=false
 	
+### Project management
 For a project management application use openxava-project-management-archetype:
 
 	mvn archetype:generate -DarchetypeGroupId=org.openxava -DarchetypeArtifactId=openxava-project-management-archetype -DarchetypeVersion=RELEASE -DgroupId=com.yourcompany -DartifactId=yourtracker -DinteractiveMode=false
 	
+### Invoicing
 For an invoicing application use openxava-invoicing-archetype:
 
 	mvn archetype:generate -DarchetypeGroupId=org.openxava -DarchetypeArtifactId=openxava-invoicing-archetype -DarchetypeVersion=RELEASE -DgroupId=com.yourcompany -DartifactId=yourinvoicing -DinteractiveMode=false	

--- a/openxava-doc/web/docs/index_en.html
+++ b/openxava-doc/web/docs/index_en.html
@@ -15,6 +15,7 @@
       <ul>
         <li><a class="wiki_link" href="getting-started_en.html">Getting started
             guide</a></li>
+          <li><a class="wiki_link" href="project-templates_en.html">Project templates</a></li>
       </ul>
       <h2 id="toc2"><a name="OpenXava documentation-Course"></a>Course</h2>
       <ul>
@@ -188,8 +189,6 @@
             module)</a></li>
         <li><a class="wiki_link" href="custom-style_en.html">Custom visual style</a></li>
         <li><a class="wiki_link" href="owasp_en.html">Web security (OWASP)</a></li>
-        <li><a class="wiki_link" href="project-templates_en.html">Project
-            templates</a></li>
         <li><a class="wiki_link" href="example-apps_en.html">Example aplications
             with source code</a></li>
         <li><a class="wiki_link" href="ai-coding-assistants_en.html">AI coding assistants</a></li>

--- a/openxava-doc/web/docs/index_es.html
+++ b/openxava-doc/web/docs/index_es.html
@@ -14,8 +14,8 @@
       <h2 id="toc1"><a name="Documentación de OpenXava-Inicio rápido"></a>Inicio
         rápido</h2>
       <ul>
-        <li><a class="wiki_link" href="getting-started_es.html">Guía de primeros
-            pasos</a></li>
+        <li><a class="wiki_link" href="getting-started_es.html">Guía de primeros pasos</a></li>
+        <li><a class="wiki_link" href="project-templates_es.html">Plantillas de proyecto</a></li>
       </ul>
       <h2 id="toc2"><a name="Documentación de OpenXava-Curso"></a>Curso</h2>
       <ul>
@@ -193,8 +193,6 @@
         <li><a class="wiki_link" href="custom-style_es.html">Estilo visual
             personalizado</a></li>
         <li><a class="wiki_link" href="owasp_es.html">Seguridad web (OWASP)</a></li>
-        <li><a class="wiki_link" href="project-templates_es.html">Plantillas de
-            proyecto</a></li>
         <li><a class="wiki_link" href="example-apps_es.html">Aplicaciones de
             ejemplo con código fuente <br>
           </a></li>

--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,8 @@
 Change Log for OpenXava project
 ===============================
 
+- Added extra headers to README.md to make specific archetypes easier to find.
+- Moved the Project Templates article to the Quick Start section of the documentation.
 - Fixed 7 security vulnerabilities in dependencies, 3 of them critical.
 - Groovy upgraded to 4.0.32.
 - json upgraded to 20260522.


### PR DESCRIPTION
- Added extra headers to README.md to make specific archetypes easier to find.
- Moved the Project Templates article to the Quick Start section of the documentation.
