### PR TITLE
UI fields

### DIFF
--- a/chattest/src/main/resources/xava.properties
+++ b/chattest/src/main/resources/xava.properties
@@ -136,7 +136,7 @@ themes=auto.css, light.css, dark.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/invoicedemo/src/main/resources/xava.properties
+++ b/invoicedemo/src/main/resources/xava.properties
@@ -113,7 +113,7 @@ smtpStartTLSEnable=false
 # i18nWarnings																		false
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-archetype-spanish/src/main/resources/xava.properties
+++ b/openxava-archetype-spanish/src/main/resources/xava.properties
@@ -160,7 +160,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-archetype/src/main/resources/xava.properties
+++ b/openxava-archetype/src/main/resources/xava.properties
@@ -151,7 +151,7 @@ themes=auto.css, light.css, dark.css
 # 	            and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-crm-archetype-spanish/src/main/resources/xava.properties
+++ b/openxava-crm-archetype-spanish/src/main/resources/xava.properties
@@ -160,7 +160,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-crm-archetype/src/main/resources/xava.properties
+++ b/openxava-crm-archetype/src/main/resources/xava.properties
@@ -156,7 +156,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-doc/web/docs/customizing_en.html
+++ b/openxava-doc/web/docs/customizing_en.html
@@ -1797,7 +1797,7 @@ value="explicitValue" &lt;!-- 4 New in v7.6 --&gt;
             <td>Possibles values for defaultLabelFormat are: <em>NORMAL, SMALL</em>
               and <em>NO_LABEL</em><br>
             </td>
-            <td>NORMAL<br>
+            <td>SMALL (since v8.0, before v8.0 it was NORMAL)<br>
             </td>
           </tr>
           <tr>

--- a/openxava-doc/web/docs/customizing_es.html
+++ b/openxava-doc/web/docs/customizing_es.html
@@ -1840,7 +1840,7 @@ private int subfamilyNumber;</code></pre>
             <td>Possibles values for defaultLabelFormat are: <em>NORMAL, SMALL</em>
               and <em>NO_LABEL</em><br>
             </td>
-            <td>NORMAL<br>
+            <td>SMALL (desde v8.0, antes de v8.0 era NORMAL)<br>
             </td>
           </tr>
           <tr>

--- a/openxava-doc/web/docs/view_en.html
+++ b/openxava-doc/web/docs/view_en.html
@@ -678,7 +678,8 @@ private int zipCode;
           rel="nofollow">LabelFormatType</a>.NO_LABEL</em> simply does not
       display the label. Since v4m4 you can use <em>defaultLabelFormat</em> in
       <em>xava.properties</em> to specify the label format to be used when <em>@LabelFormat</em>
-      is omitted.<br>
+      is omitted. Since v8.0 the default value for <em>defaultLabelFormat</em>
+      is <em>SMALL</em>, before v8.0 it was <em>NORMAL</em>.<br>
       <h3 id="toc10"><a name="View-Property customization-Property value change event"></a>Property
         value change event</h3>
       If you wish to react to the event of a value change of a property you can

--- a/openxava-doc/web/docs/view_en.html
+++ b/openxava-doc/web/docs/view_en.html
@@ -668,14 +668,13 @@ private int zipCode;
 </code></pre>
       In this case the zip code is displayed as:<br>
       <img src="files/view_en100.jpg" alt="view_en100.jpg" title="view_en100.jpg"><br>
-      The <em><a class="wiki_link_ext" href="http://www.openxava.org/OpenXavaDoc/apidocs/org/openxava/annotations/LabelFormatType.html"
+      The <em><a href="http://www.openxava.org/OpenXavaDoc/apidocs/org/openxava/annotations/LabelFormatType.html"
 
-          rel="nofollow">LabelFormatType</a>.NORMAL</em> format is the default
-      style (with a normal label at the left) and the <em><a class="wiki_link_ext"
+          >LabelFormatType</a>.NORMAL</em> format is a normal label at the left and the <em><a
 
           href="http://www.openxava.org/OpenXavaDoc/apidocs/org/openxava/annotations/LabelFormatType.html"
 
-          rel="nofollow">LabelFormatType</a>.NO_LABEL</em> simply does not
+          >LabelFormatType</a>.NO_LABEL</em> simply does not
       display the label. Since v4m4 you can use <em>defaultLabelFormat</em> in
       <em>xava.properties</em> to specify the label format to be used when <em>@LabelFormat</em>
       is omitted. Since v8.0 the default value for <em>defaultLabelFormat</em>

--- a/openxava-doc/web/docs/view_es.html
+++ b/openxava-doc/web/docs/view_es.html
@@ -672,14 +672,13 @@ private tipo nombrePropiedad;</code></pre>
 private int codigoPostal;</code></pre>
       En este caso el código postal lo visualiza así:<br>
       <img src="files/view_es100.jpg" alt="view_es100.jpg" title="view_es100.jpg"><br>
-      El formato <em><a class="wiki_link_ext" href="http://www.openxava.org/OpenXavaDoc/apidocs/org/openxava/annotations/LabelFormatType.html"
+      El formato <em><a  href="http://www.openxava.org/OpenXavaDoc/apidocs/org/openxava/annotations/LabelFormatType.html"
 
-          rel="nofollow">LabelFormatType</a>.NORMAL</em> es el que hemos visto
-      hasta ahora (con la etiqueta grande y la izquierda) y el formato <em><a class="wiki_link_ext"
+          >LabelFormatType</a>.NORMAL</em> es la etiqueta grande y la izquierda y el formato <em><a
 
           href="http://www.openxava.org/OpenXavaDoc/apidocs/org/openxava/annotations/LabelFormatType.html"
 
-          rel="nofollow">LabelFormatType</a>.NO_LABEL</em> simplemente hace que
+          >LabelFormatType</a>.NO_LABEL</em> simplemente hace que
       no salga etiqueta. A partir de v4m4 puedes usar <em>defaultLabelFormat</em>
       en <em>xava.properties</em> para especificar el formato a usar cuando se
       omita <em>@LabelFormat</em>. A partir de v8.0 el valor por defecto de <em>defaultLabelFormat</em>

--- a/openxava-doc/web/docs/view_es.html
+++ b/openxava-doc/web/docs/view_es.html
@@ -682,7 +682,8 @@ private int codigoPostal;</code></pre>
           rel="nofollow">LabelFormatType</a>.NO_LABEL</em> simplemente hace que
       no salga etiqueta. A partir de v4m4 puedes usar <em>defaultLabelFormat</em>
       en <em>xava.properties</em> para especificar el formato a usar cuando se
-      omita <em>@LabelFormat</em>.<br>
+      omita <em>@LabelFormat</em>. A partir de v8.0 el valor por defecto de <em>defaultLabelFormat</em>
+      es <em>SMALL</em>, antes de v8.0 era <em>NORMAL</em>.<br>
       <h3 id="toc10"><a name="Vista-Personalizacion+de+propiedad-Evento+de+cambio+de+valor+de+propiedad"></a>Evento
         de cambio de valor de propiedad</h3>
       Si queremos reaccionar al evento de cambio de valor de una propiedad

--- a/openxava-invoicing-archetype-spanish/src/main/resources/xava.properties
+++ b/openxava-invoicing-archetype-spanish/src/main/resources/xava.properties
@@ -160,7 +160,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-invoicing-archetype/src/main/resources/xava.properties
+++ b/openxava-invoicing-archetype/src/main/resources/xava.properties
@@ -156,7 +156,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-master-detail-archetype-spanish/src/main/resources/xava.properties
+++ b/openxava-master-detail-archetype-spanish/src/main/resources/xava.properties
@@ -160,7 +160,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-master-detail-archetype/src/main/resources/xava.properties
+++ b/openxava-master-detail-archetype/src/main/resources/xava.properties
@@ -156,7 +156,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-project-management-archetype-spanish/src/main/resources/xava.properties
+++ b/openxava-project-management-archetype-spanish/src/main/resources/xava.properties
@@ -160,7 +160,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava-project-management-archetype/src/main/resources/xava.properties
+++ b/openxava-project-management-archetype/src/main/resources/xava.properties
@@ -156,7 +156,7 @@ themes=terra.css, light.css, dark.css, black-and-white.css, blue.css
 #             and labels (e.g. en,es,fr).
 #
 # Application and Controllers
-# defaultLabelFormat	Possibles values for defaultLabelFormat are:				NORMAL 
+# defaultLabelFormat	Possibles values for defaultLabelFormat are:				SMALL 
 #						NORMAL, SMALL and NO_LABEL
 # defaultLabelStyle	Pre-defined: bold-label, italic-label							default (???)
 # defaultModeController	Possibles values for defaultModeController are:				Mode

--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,12 @@
 Change Log for OpenXava project
 ===============================
 
+- Text fields, selects and textareas redesigned: 1px border, 8px corner radius, taller and more comfortable (38px), hover border, accent focus ring and softer disabled state.
+- Required properties and references are now marked with a red asterisk next to the label, instead of a darker field border.
+- Boolean properties in detail view use a modern switch (toggle) editor instead of a checkbox.
+- Property labels use medium font weight and a softer color for a cleaner, less noisy look.
+- Numeric fields use tabular-nums so digits align when comparing values.
+- New CSS variables for field customization: --input-hover-border, --placeholder-color, --disabled-input-color, --label-color, --required-indicator-color, --select-chevron-icon, --switch-off-background, --switch-off-hover-background, --switch-on-background, --switch-on-hover-background, --switch-knob-background.
 - Modules menu widened from 180px to 260px with hairline border, pill-shaped rows and accent-colored selection.
 - Magnifier icon added inside the module search input; input has visible border at rest and subtle 2px focus ring at 20% opacity.
 - Module menu show/hide toggles redesigned as circular button (hide) and vertical tab (show) with accent hover and elevation.

--- a/openxava/changelog.txt
+++ b/openxava/changelog.txt
@@ -1,6 +1,7 @@
 Change Log for OpenXava project
 ===============================
 
+- Default value for defaultLabelFormat in xava.properties changed from NORMAL to SMALL, so property labels are now displayed in small format by default.
 - Text fields, selects and textareas redesigned: 1px border, 8px corner radius, taller and more comfortable (38px), hover border, accent focus ring and softer disabled state.
 - Required properties and references are now marked with a red asterisk next to the label, instead of a darker field border.
 - Boolean properties in detail view use a modern switch (toggle) editor instead of a checkbox.

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -2,6 +2,7 @@ Pending UI8 modernization (tmr)
 -------------------------------
 
 - Bloque 2b.
+    - Etiqueta a la izquierda.
 - Bloque 3.
 - Loading moderno, quizás una barra de progreso. El indicador actual es como el GMail original.
 - Revisar como han quedado y ver sin son susceptibles de modernización:
@@ -10,6 +11,8 @@ Pending UI8 modernization (tmr)
     - Secciones.
     - Marcos.
     - Acciones en vista.
+    - Editor de carga de archivos. Al menos el color.
+    - Editor de texto rico.
 - Suite.
 - Prueba manuales.
 - Documentación:

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -3,7 +3,8 @@ Pending UI8 modernization (tmr)
 
 - Bloque 2b.
     - Etiqueta a la izquierda.
-        - Preguntar a Kimi su opinión.
+        - Corregir espacio entre Via publica y su campo, en Invoice. TMR ME QUEDÉ POR AQUÍ.
+            TMR LO DEMÁS YA ESTÁ BIEN. INCLUIDO ESPACIADOS, ALINACIÓN, COLOR, TAMAÑO, ETC.
         - Probar grabar booleanos.
         - Espaciado, ahora hay más.
         - En arquetipos y otra apps

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -4,7 +4,7 @@ Pending UI8 modernization (tmr)
 - Bloque 2b.
     - Etiqueta a la izquierda.
         - Falta revisar doc.
-            - Customization
+            * Customization
             - ¿Poner en migración?
             - changelog
         - Modificar prueba manuales.

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -9,6 +9,7 @@ Pending UI8 modernization (tmr)
     - Botones de abajo.
     - Secciones.
     - Marcos.
+    - Acciones en vista.
 - Suite.
 - Prueba manuales.
 - Documentación:

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -3,10 +3,8 @@ Pending UI8 modernization (tmr)
 
 - Bloque 2b.
     - Etiqueta a la izquierda.
-        - Alienar etiqueta booleanos. TMR ME QUEDÉ HACIENDO ESTO
-            Pagada en Invoice, sin romper la alineaciones de abajo
-        - Probar grabar booleanos.
         - Preguntar a Kimi su opinión.
+        - Probar grabar booleanos.
         - Espaciado, ahora hay más.
         - En arquetipos y otra apps
         - Falta revisar doc.

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -2,12 +2,6 @@ Pending UI8 modernization (tmr)
 -------------------------------
 
 - Bloque 2b.
-    - Etiqueta a la izquierda.
-        - Falta revisar doc.
-            * Customization
-            - ¿Poner en migración?
-            - changelog
-        - Modificar prueba manuales.
     - Probar grabar booleanos.
     - InvoiceTest
 - Bloque 3.

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -3,6 +3,9 @@ Pending UI8 modernization (tmr)
 
 - Bloque 2b.
     - Etiqueta a la izquierda.
+        - Alienar etiqueta booleanos. TMR ME QUEDÉ HACIENDO ESTO
+            Pagada en Invoice, sin romper la alineaciones de abajo
+        - Probar grabar booleanos.
         - Preguntar a Kimi su opinión.
         - Espaciado, ahora hay más.
         - En arquetipos y otra apps

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -9,6 +9,7 @@ Pending UI8 modernization (tmr)
         - Falta revisar doc.
             - ¿Poner en migración?
             - changelog
+    - InvoiceTest
 - Bloque 3.
 - Loading moderno, quizás una barra de progreso. El indicador actual es como el GMail original.
 - Revisar como han quedado y ver sin son susceptibles de modernización:

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -3,8 +3,8 @@ Pending UI8 modernization (tmr)
 
 - Bloque 2b.
     - Etiqueta a la izquierda.
-        - En arquetipos y otra apps
         - Falta revisar doc.
+            - Customization
             - ¿Poner en migración?
             - changelog
         - Modificar prueba manuales.

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -1,9 +1,8 @@
 Pending UI8 modernization (tmr)
 -------------------------------
 
-- Bloque 2b.
-    - Probar grabar booleanos.
-    - InvoiceTest
+- Bloque 2c.
+- Bloque 2d.
 - Bloque 3.
 - Loading moderno, quizás una barra de progreso. El indicador actual es como el GMail original.
 - Revisar como han quedado y ver sin son susceptibles de modernización:

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -3,6 +3,12 @@ Pending UI8 modernization (tmr)
 
 - Bloque 2b.
     - Etiqueta a la izquierda.
+        - Preguntar a Kimi su opinión.
+        - Espaciado, ahora hay más.
+        - En arquetipos y otra apps
+        - Falta revisar doc.
+            - ¿Poner en migración?
+            - changelog
 - Bloque 3.
 - Loading moderno, quizás una barra de progreso. El indicador actual es como el GMail original.
 - Revisar como han quedado y ver sin son susceptibles de modernización:
@@ -13,6 +19,7 @@ Pending UI8 modernization (tmr)
     - Acciones en vista.
     - Editor de carga de archivos. Al menos el color.
     - Editor de texto rico.
+    - Small label.
 - Suite.
 - Prueba manuales.
 - Documentación:

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -3,14 +3,12 @@ Pending UI8 modernization (tmr)
 
 - Bloque 2b.
     - Etiqueta a la izquierda.
-        - Corregir espacio entre Via publica y su campo, en Invoice. TMR ME QUEDÉ POR AQUÍ.
-            TMR LO DEMÁS YA ESTÁ BIEN. INCLUIDO ESPACIADOS, ALINACIÓN, COLOR, TAMAÑO, ETC.
-        - Probar grabar booleanos.
-        - Espaciado, ahora hay más.
         - En arquetipos y otra apps
         - Falta revisar doc.
             - ¿Poner en migración?
             - changelog
+        - Modificar prueba manuales.
+    - Probar grabar booleanos.
     - InvoiceTest
 - Bloque 3.
 - Loading moderno, quizás una barra de progreso. El indicador actual es como el GMail original.

--- a/openxava/pending.txt
+++ b/openxava/pending.txt
@@ -12,6 +12,7 @@ Pending UI8 modernization (tmr)
 - Suite.
 - Prueba manuales.
 - Documentación:
+    - Mirar todos los hilos y revisar migración.
     - Rehacer custom-style_en/es.html
 - Refinar y resumir entradas en changelog
 - Borrar MDs.

--- a/openxava/src/main/java/org/openxava/util/XavaPreferences.java
+++ b/openxava/src/main/java/org/openxava/util/XavaPreferences.java
@@ -342,7 +342,7 @@ public class XavaPreferences {
 		if (defaultLabelFormat >= 0)
 			return defaultLabelFormat;
 		String labelFormat = getProperties().getProperty("defaultLabelFormat",
-				"NORMAL");
+				"SMALL");
 		if (labelFormat.equalsIgnoreCase("NORMAL"))
 			defaultLabelFormat = MetaPropertyView.NORMAL_LABEL;
 		else if (labelFormat.equalsIgnoreCase("SMALL"))

--- a/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
@@ -57,14 +57,14 @@ public class PropertyEditorRenderer {
 		String postEditor = LayoutCells.postEditor();
 
 		if (!hasFrame) {
-			w.append(preLabel);
 			if (labelFormat == MetaPropertyView.NORMAL_LABEL) {
+				w.append(preLabel);
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + p.getName()))
 					.append("' class='").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.append(label);
 				w.append("</span>");
+				w.append(postLabel);
 			}
-			w.append(postLabel);
 			w.append(preEditor);
 			if (labelFormat == MetaPropertyView.SMALL_LABEL) {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + p.getName()))

--- a/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
@@ -51,6 +51,9 @@ public class PropertyEditorRenderer {
 		String preLabel = LayoutCells.preLabel(view, style, first);
 		String postLabel = LayoutCells.postLabel();
 		String preEditor = LayoutCells.preEditor(view, style, first);
+		if (labelFormat == MetaPropertyView.SMALL_LABEL) {
+			preEditor = preEditor.replace("ox-editor-wrapper'", "ox-editor-wrapper ox-small-label-wrapper'");
+		}
 		String postEditor = LayoutCells.postEditor();
 
 		if (!hasFrame) {
@@ -67,7 +70,7 @@ public class PropertyEditorRenderer {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + p.getName()))
 					.append("' class='").append(style.getSmallLabel()).append(" ").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.append(label);
-				w.append("</span><br/>");
+				w.append("</span>");
 			}
 		}
 

--- a/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
@@ -64,6 +64,11 @@ public class PropertyEditorRenderer {
 				w.append(label);
 				w.append("</span>");
 				w.append(postLabel);
+			} else if (first || view.isAlignedByColumns()) {
+				// Empty label cell so SMALL/NO_LABEL fields do not widen the
+				// shared first column and misalign NORMAL fields.
+				w.append(preLabel);
+				w.append(postLabel);
 			}
 			w.append(preEditor);
 			if (labelFormat == MetaPropertyView.SMALL_LABEL) {

--- a/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/PropertyEditorRenderer.java
@@ -40,6 +40,8 @@ public class PropertyEditorRenderer {
 		if (Is.empty(labelStyle)) labelStyle = XavaPreferences.getInstance().getDefaultLabelStyle();
 		String label = view.getLabelFor(p);
 		if (first && !view.isAlignedByColumns()) label = Strings.change(label, " ", "&nbsp;");
+		boolean required = view.isEditable() && p.isRequired();
+		String requiredLabelClass = required ? " " + style.getRequiredLabel() : "";
 
 		HtmlWriter w = new HtmlWriter();
 
@@ -55,7 +57,7 @@ public class PropertyEditorRenderer {
 			w.append(preLabel);
 			if (labelFormat == MetaPropertyView.NORMAL_LABEL) {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + p.getName()))
-					.append("' class='").append(labelStyle).append("'>");
+					.append("' class='").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.append(label);
 				w.append("</span>");
 			}
@@ -63,7 +65,7 @@ public class PropertyEditorRenderer {
 			w.append(preEditor);
 			if (labelFormat == MetaPropertyView.SMALL_LABEL) {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + p.getName()))
-					.append("' class='").append(style.getSmallLabel()).append(" ").append(labelStyle).append("'>");
+					.append("' class='").append(style.getSmallLabel()).append(" ").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.append(label);
 				w.append("</span><br/>");
 			}
@@ -71,11 +73,11 @@ public class PropertyEditorRenderer {
 
 		// Editor span
 		String placeholder = !Is.empty(p.getPlaceholder()) ? "data-placeholder='" + p.getPlaceholder() + "'" : "";
-		String required = view.isEditable() && p.isRequired() ? style.getRequiredEditor() : "";
+		String requiredClass = required ? style.getRequiredEditor() : "";
 		String transientClass = p.isTransient() ? "xava_transient" : "";
 
 		w.append("<span id='").append(ctx.decorateId("editor_" + view.getPropertyPrefix() + p.getName()))
-			.append("' class='xava_editor ").append(required).append(" ").append(transientClass)
+			.append("' class='xava_editor ").append(requiredClass).append(" ").append(transientClass)
 			.append("' ").append(placeholder).append(">");
 
 		// Delegate the actual editor to editorWrapper.jsp (uses <xava:editor> tag)

--- a/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
@@ -80,6 +80,11 @@ public class ReferenceRenderer {
 				w.text(label);
 				w.append("</span>");
 				w.append(postLabel);
+			} else if (first || view.isAlignedByColumns()) {
+				// Empty label cell so SMALL/NO_LABEL references do not widen the
+				// shared first column and misalign NORMAL fields.
+				w.append(preLabel);
+				w.append(postLabel);
 			}
 			w.append(preEditor);
 			if (labelFormat == MetaPropertyView.SMALL_LABEL) {

--- a/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
@@ -73,14 +73,14 @@ public class ReferenceRenderer {
 		String postEditor = LayoutCells.postEditor();
 
 		if (!onlyEditor) {
-			w.append(preLabel);
 			if (labelFormat == MetaPropertyView.NORMAL_LABEL) {
+				w.append(preLabel);
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + ref.getName()))
 					.append("' class='").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.text(label);
 				w.append("</span>");
+				w.append(postLabel);
 			}
-			w.append(postLabel);
 			w.append(preEditor);
 			if (labelFormat == MetaPropertyView.SMALL_LABEL) {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + ref.getName()))

--- a/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
@@ -54,6 +54,7 @@ public class ReferenceRenderer {
 		String labelStyle = view.getLabelStyleForReference(ref);
 		if (Is.empty(labelStyle)) labelStyle = XavaPreferences.getInstance().getDefaultLabelStyle();
 		String label = view.getLabelFor(ref);
+		String requiredLabelClass = editable && ref.isRequired() ? " " + style.getRequiredLabel() : "";
 
 		HtmlWriter w = new HtmlWriter();
 
@@ -72,7 +73,7 @@ public class ReferenceRenderer {
 			w.append(preLabel);
 			if (labelFormat == MetaPropertyView.NORMAL_LABEL) {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + ref.getName()))
-					.append("' class='").append(labelStyle).append("'>");
+					.append("' class='").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.text(label);
 				w.append("</span>");
 			}
@@ -80,7 +81,7 @@ public class ReferenceRenderer {
 			w.append(preEditor);
 			if (labelFormat == MetaPropertyView.SMALL_LABEL) {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + ref.getName()))
-					.append("' class='").append(style.getSmallLabel()).append(" ").append(labelStyle).append("'>");
+					.append("' class='").append(style.getSmallLabel()).append(" ").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.text(label);
 				w.append("</span><br/>");
 			}

--- a/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
+++ b/openxava/src/main/java/org/openxava/web/render/ReferenceRenderer.java
@@ -67,6 +67,9 @@ public class ReferenceRenderer {
 		String preLabel = LayoutCells.preLabel(view, style, first);
 		String postLabel = LayoutCells.postLabel();
 		String preEditor = LayoutCells.preEditor(view, style, first);
+		if (labelFormat == MetaPropertyView.SMALL_LABEL) {
+			preEditor = preEditor.replace("ox-editor-wrapper'", "ox-editor-wrapper ox-small-label-wrapper'");
+		}
 		String postEditor = LayoutCells.postEditor();
 
 		if (!onlyEditor) {
@@ -83,7 +86,7 @@ public class ReferenceRenderer {
 				w.append("<span id='").append(ctx.decorateId("label_" + view.getPropertyPrefix() + ref.getName()))
 					.append("' class='").append(style.getSmallLabel()).append(" ").append(labelStyle).append(requiredLabelClass).append("'>");
 				w.text(label);
-				w.append("</span><br/>");
+				w.append("</span>");
 			}
 		}
 

--- a/openxava/src/main/java/org/openxava/web/style/Style.java
+++ b/openxava/src/main/java/org/openxava/web/style/Style.java
@@ -1021,6 +1021,13 @@ public class Style {
 	}
 	
 	/**
+	 * @since 8.0
+	 */
+	public String getRequiredLabel() { 
+		return "ox-required-label";
+	}
+	
+	/**
 	 * Determines if the html content has a class attribute with the getFrame() code and replace its content
 	 * with getFrame() getFrameSibling combination.
 	 * @param html Html text to be manipulated.

--- a/openxava/src/main/resources/META-INF/resources/xava/editors/booleanEditor.jsp
+++ b/openxava/src/main/resources/META-INF/resources/xava/editors/booleanEditor.jsp
@@ -11,7 +11,7 @@ String checked=Boolean.TRUE.equals(value)?"checked='true'":"";
 boolean editable="true".equals(request.getParameter("editable"));
 String disabled=editable?"":"disabled";
 %>
-<INPUT id="<%=propertyKey%>" type="checkbox" name="<%=propertyKey%>" class=<%=style.getEditor()%>
+<INPUT id="<%=propertyKey%>" type="checkbox" name="<%=propertyKey%>" class="<%=style.getEditor()%> ox-switch"
 	tabindex="1" 
 	value="true" 
 	title="<%=p.getDescription(request)%>"	

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -899,7 +899,7 @@ input[type="text"]:disabled, input[type="password"]:disabled, input[type="file"]
 
 .ox-web-url a {
 	position: relative; 
-	right: 25px;
+	right: 28px;
 }
 
 .flatpickr-day.selected {

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -949,7 +949,7 @@ input[type="checkbox"]:focus-visible {
 }
 
 .ox-list-subheader input[type="text"] { 
-    height: 28px;
+    height: 38px;
     width: 100%; 
     box-sizing: border-box; 
     -moz-box-sizing: border-box; 
@@ -958,6 +958,7 @@ input[type="checkbox"]:focus-visible {
 
 .ox-list-subheader select {
 	width: 100%;
+	height: 38px;
 }
 
 .ox-list-subheader-resize {

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -949,16 +949,21 @@ input[type="checkbox"]:focus-visible {
 }
 
 .ox-list-subheader input[type="text"] { 
-    height: 38px;
+    height: 32px;
     width: 100%; 
     box-sizing: border-box; 
     -moz-box-sizing: border-box; 
     -webkit-box-sizing: border-box;
 }
 
-.ox-list-subheader select {
+.ox-list-subheader select:not([multiple]) {
 	width: 100%;
-	height: 38px;
+	height: 32px;
+}
+
+select.xava_list_configurations:not([multiple]),
+select.xava_group_by:not([multiple]) {
+	height: 32px;
 }
 
 .ox-list-subheader-resize {

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -1003,8 +1003,8 @@ select:not([multiple]) {
 	vertical-align: middle;
 }
 
-.ox-editor-wrapper { 
-	padding: 1px 12px 5px 0px; 
+.ox-editor-wrapper {
+	padding: 1px 12px 5px 0px;
 }
 
 input[type="text"]:focus, input[type="password"]:focus, input[type="file"]:focus, input[type="date"]:focus, input[type="datetime-local"]:focus, select:focus, textarea:focus {   
@@ -2415,11 +2415,15 @@ div.ox-subcontroller table{
 	font-weight: bold;
 }
 
-.small-label { 
-	padding-left: 6px;
-	margin-bottom: 2px;
+.small-label {
+	display: block;
+	padding-left: 0;
+	margin-top: var(--space-3);
+	margin-bottom: var(--space-1);
+	font-size: var(--font-size-sm);
 	font-weight: 500;
 	color: var(--label-color);
+	line-height: 1.3;
 }
 
 .bold-label {

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -2426,6 +2426,19 @@ div.ox-subcontroller table{
 	line-height: 1.3;
 }
 
+.ox-editor-wrapper .xava_editor {
+	display: inline-flex;
+	align-items: center;
+	min-height: 38px;
+}
+
+.ox-editor-wrapper .xava_editor::before {
+	content: "";
+	width: 0;
+	height: calc(20px + (var(--space-2) / 2) + 1px);
+	align-self: baseline;
+}
+
 .bold-label {
 	font-weight:bold;
 }

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -236,11 +236,22 @@
 	--attached-file-color: #5755D2;	
 
 	--input-border: #cbd5e1;
+	--input-hover-border: #94a3b8;
 	--input-focus-border: var(--default-action-button-background);
 	--input-color: black;
 	--input-background: white; 
+	--placeholder-color: #94a3b8;
 	--error-editor-border: #DC4A38;
 	--disabled-input-background: #f1f5f9;
+	--disabled-input-color: #64748b;
+	--label-color: #334155;
+	--required-indicator-color: #dc2626;
+	--select-chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2.5 4.25 6 7.75 9.5 4.25' fill='none' stroke='%2364748b' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+	--switch-off-background: #cbd5e1;
+	--switch-off-hover-background: #94a3b8;
+	--switch-on-background: var(--accent-color);
+	--switch-on-hover-background: var(--accent-color-hover);
+	--switch-knob-background: white;
 	--xava-placeholder-background: #f1f5f9;
 	
 	--icon-i-color: var(--action-color);
@@ -249,7 +260,7 @@
 	--icons-list-i-hover-color: black;
 	--icons-list-background: var(--background);
 	--icons-list-i-hover-background: var(--action-hover-background);	
-	--crop-free-icon-color: var(--required-editor-border);
+	--crop-free-icon-color: #94a3b8;
 	--plus-icon-color: var(--crop-free-icon-color);
 	--scrollbar-background: linear-gradient(
 			to top,
@@ -782,35 +793,95 @@ input[type="text"], input[type="password"], input[type="file"], input[type="date
 input[type="datetime-local"], .ui-widget input[type="datetime-local"], 
 .ui-widget input[type="text"], .ui-widget input[type="password"], .ui-widget input[type="file"], .ui-widget input[type="date"],  
 .ui-widget select, .ui-widget textarea {   
-	border-color: var(--input-border);  
-	border-style: solid;	
-	border-width: 2px; 
+	border: 1px solid var(--input-border);  
 	font-size: var(--font-size-md);  
-	border-radius: var(--radius-sm);
-	color: var(--input-color);
-	background: var(--input-background); 
-	transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-textarea, .ui-widget textarea {   
 	border-radius: var(--radius-md);
 	color: var(--input-color);
+	background: var(--input-background); 
+	transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
+}
+
+:is(input[type="text"], input[type="password"], input[type="file"], input[type="date"], input[type="datetime-local"], select, textarea):hover:not(:disabled):not(:focus) {
+	border-color: var(--input-hover-border);
+}
+
+::placeholder {
+	color: var(--placeholder-color);
+	opacity: 1;
 }
 
 input[type="text"], input[type="password"], input[type="file"], input[type="date"], input[type="datetime-local"], textarea { 
-	padding: var(--space-1);
+	padding: var(--space-2) var(--space-3);
 }
 
 input[type="text"], input[type="password"], input[type="file"], input[type="date"], input[type="datetime-local"] {  
 	height: 20px;
 }
 
-input[type="text"]:disabled, input[type="password"]:disabled, input[type="file"]:disabled, input[type="date"]:disabled, input[type="datetime-local"]:disabled, textarea:disabled {  
+input[type="text"]:disabled, input[type="password"]:disabled, input[type="file"]:disabled, input[type="date"]:disabled, input[type="datetime-local"]:disabled, select:disabled, textarea:disabled {  
 	background: var(--disabled-input-background);
+	color: var(--disabled-input-color);
+	cursor: default;
 }
 
-.xava_editor input[type="checkbox"] {
-	vertical-align: middle; 
+.xava_numeric {
+	font-variant-numeric: tabular-nums;
+}
+
+.xava_editor input.ox-switch {
+	-webkit-appearance: none;
+	appearance: none;
+	box-sizing: border-box;
+	width: 40px;
+	height: 24px;
+	margin: 0;
+	padding: 0;
+	border: none;
+	border-radius: var(--radius-full);
+	background: var(--switch-off-background);
+	vertical-align: middle;
+	position: relative;
+	cursor: pointer;
+	transition: background-color var(--transition-fast);
+}
+
+.xava_editor input.ox-switch::after {
+	content: "";
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	background: var(--switch-knob-background);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+	transition: transform var(--transition-normal);
+}
+
+.xava_editor input.ox-switch:hover:not(:disabled):not(:checked) {
+	background: var(--switch-off-hover-background);
+}
+
+.xava_editor input.ox-switch:checked {
+	background: var(--switch-on-background);
+}
+
+.xava_editor input.ox-switch:checked:hover:not(:disabled) {
+	background: var(--switch-on-hover-background);
+}
+
+.xava_editor input.ox-switch:checked::after {
+	transform: translateX(16px);
+}
+
+.xava_editor input.ox-switch:disabled {
+	opacity: 0.55;
+	cursor: default;
+}
+
+.ox-element-collection .xava_editor input.ox-switch {
+	display: block;
+	margin: 2px auto;
 }
 
 .ox-list input[type="checkbox"] {
@@ -855,6 +926,7 @@ input[type="text"]:disabled, input[type="password"]:disabled, input[type="file"]
 input[type="radio"] {
 	margin: 4px 0px 4px 10px;
 	vertical-align: middle;
+	accent-color: var(--accent-color);
 }
 
 input[type="radio"]:focus-visible {
@@ -897,14 +969,28 @@ input[type="checkbox"]:focus-visible {
 }
 
 select:not([multiple]) { 
-	height: 30px;
-	padding: 5px;
+	-webkit-appearance: none;
+	appearance: none;
+	box-sizing: border-box;
+	height: 38px;
+	padding: 0 var(--space-7) 0 var(--space-3);
+	background-image: var(--select-chevron-icon);
+	background-repeat: no-repeat;
+	background-position: right var(--space-2) center;
+	cursor: pointer;
 }
 
 .ox-label { 
-	padding-right: 7px;
-	font-weight: bold;
+	padding-right: var(--space-2);
+	font-weight: 500;
+	color: var(--label-color);
 	vertical-align: baseline;
+}
+
+.ox-required-label::after {
+	content: " *";
+	color: var(--required-indicator-color);
+	font-weight: 600;
 }
 
 .ox-label.ox-label-tall-row {
@@ -918,6 +1004,7 @@ select:not([multiple]) {
 input[type="text"]:focus, input[type="password"]:focus, input[type="file"]:focus, input[type="date"]:focus, input[type="datetime-local"]:focus, select:focus, textarea:focus {   
 	outline: 0;
 	border-color: var(--input-focus-border) !important; 
+	box-shadow: 0 0 0 3px var(--focus-ring-color);
 }
 
 .module-wrapper {
@@ -1662,6 +1749,7 @@ input[type="button"] {
 	-moz-box-sizing: border-box; 
 	-webkit-box-sizing: border-box;
 	height: 30px;
+	padding: var(--space-1) var(--space-2);
 }
 
 .ox-list-cell-editor .ox-descriptions-list {
@@ -1676,7 +1764,7 @@ input[type="button"] {
 	top: -5px;
 }
 
-.ox-element-collection input[type="checkbox"] {
+.ox-element-collection input[type="checkbox"]:not(.ox-switch) {
 	height: inherit;
 	margin-left: auto;
     margin-right: auto;
@@ -1829,7 +1917,8 @@ input[id$="_SignIn__AzureAD___signInWithAzureAD"] {
 	width: 220px;	
 }
 #sign_in_box select {
-	height: auto;	
+	box-sizing: border-box;
+	width: 246px;
 }
 
 .ox-frame-title {
@@ -2323,7 +2412,8 @@ div.ox-subcontroller table{
 .small-label { 
 	padding-left: 6px;
 	margin-bottom: 2px;
-	font-weight: bold; 
+	font-weight: 500;
+	color: var(--label-color);
 }
 
 .bold-label {

--- a/openxava/src/main/resources/META-INF/resources/xava/style/base.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/base.css
@@ -244,7 +244,7 @@
 	--error-editor-border: #DC4A38;
 	--disabled-input-background: #f1f5f9;
 	--disabled-input-color: #64748b;
-	--label-color: #334155;
+	--label-color: #1e293b;
 	--required-indicator-color: #dc2626;
 	--select-chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2.5 4.25 6 7.75 9.5 4.25' fill='none' stroke='%2364748b' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 	--switch-off-background: #cbd5e1;
@@ -2418,7 +2418,7 @@ div.ox-subcontroller table{
 .small-label {
 	display: block;
 	padding-left: 0;
-	margin-top: var(--space-3);
+	margin-top: var(--space-2);
 	margin-bottom: var(--space-1);
 	font-size: var(--font-size-sm);
 	font-weight: 500;

--- a/openxava/src/main/resources/META-INF/resources/xava/style/dark-overrides.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/dark-overrides.css
@@ -58,12 +58,22 @@
 	--reference-search-icon-color: var(--my-dark);
 
 	/* Editors */
-	--required-editor-border: var(--my-silver);
+	--required-editor-border: var(--input-border);
+	--required-indicator-color: #f87171;
 	--input-focus-border: var(--accent-color);
 	--input-color: var(--my-silver);
 	--input-border: #3f3f46;
+	--input-hover-border: #52525b;
 	--input-background: transparent;
+	--placeholder-color: #71717a;
 	--disabled-input-background: var(--my-lightdark);
+	--disabled-input-color: #71717a;
+	--label-color: #d4d4d8;
+	--select-chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2.5 4.25 6 7.75 9.5 4.25' fill='none' stroke='%23a1a1aa' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+	--switch-off-background: #3f3f46;
+	--switch-off-hover-background: #52525b;
+	--switch-knob-background: #d4d4d8;
+	--crop-free-icon-color: #a1a1aa;
 	--calendar-selected-day: var(--my-blue);
 
 	--button-bar-shadow: transparent;

--- a/openxava/src/main/resources/META-INF/resources/xava/style/dark-overrides.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/dark-overrides.css
@@ -68,7 +68,7 @@
 	--placeholder-color: #71717a;
 	--disabled-input-background: var(--my-lightdark);
 	--disabled-input-color: #71717a;
-	--label-color: #d4d4d8;
+	--label-color: #e4e4e7;
 	--select-chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2.5 4.25 6 7.75 9.5 4.25' fill='none' stroke='%23a1a1aa' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 	--switch-off-background: #3f3f46;
 	--switch-off-hover-background: #52525b;

--- a/openxava/src/main/resources/META-INF/resources/xava/style/layout.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/layout.css
@@ -3,6 +3,10 @@
 	white-space: nowrap; 
 }
 
+.ox-layout-aligned-cell.ox-label:empty {
+	padding: 0;
+}
+
 .ox-layout-aligned-cell {
 	display: table-cell;
 }

--- a/openxava/src/main/resources/META-INF/resources/xava/style/light.css
+++ b/openxava/src/main/resources/META-INF/resources/xava/style/light.css
@@ -44,7 +44,7 @@
 	--default-action-button-hover-background: var(--accent-color-hover);
 
 	/* Editors */
-	--required-editor-border: #94a3b8;
+	--required-editor-border: var(--input-border);
 	--calendar-selected-day: var(--accent-color);
 
 }

--- a/openxava/ui8-modernization-bloque2b-thread.md
+++ b/openxava/ui8-modernization-bloque2b-thread.md
@@ -148,3 +148,14 @@ El problema de alineación se resolvió aplicando la misma baseline de 38px a **
 - El usuario hizo un push con los cambios confirmados (puntos 1-4) antes de seguir con el problema del booleano.
 - Los puntos 5 y 6 (min-height + vertical-align:top) están en el código pero NO resuelven completamente el problema del booleano.
 - Hay que decidir si mantener los puntos 5 y 6 o revertirlos si no se encuentra solución.
+
+## Ajustes de refinamiento (2026-08-21)
+
+Tras revisar un pantallazo de Facturas con las nuevas etiquetas, se aplicaron 4 ajustes:
+
+1. **Espaciado vertical entre campos reducido**: `.small-label` `margin-top` de `--space-3` (12px) a `--space-2` (8px) en base.css. Total entre campos ≈13px (8px + 5px de padding inferior del wrapper). El gap etiqueta→campo se mantiene en 4px (`--space-1`).
+2. **Etiquetas más oscuras en tema claro**: `--label-color` de `#334155` a `#1e293b` (slate-700 → slate-800) en base.css.
+3. **Etiquetas con más contraste en tema oscuro**: `--label-color` de `#d4d4d8` a `#e4e4e7` (zinc-300 → zinc-200) en dark-overrides.css.
+4. **Marcos alineados con los campos**: causa raíz — para etiquetas SMALL/NO_LABEL se emitía un `<div class='ox-layout-...-cell ox-label'>` **vacío** antes del campo; al ser `table-cell` (primera celda de fila) generaba una tabla anónima con border-spacing + whitespace (~8px) que desplazaba los campos a la derecha del borde del marco. Fix en `PropertyEditorRenderer.java` y `ReferenceRenderer.java`: la celda de etiqueta (`preLabel`/`postLabel`) solo se emite cuando hay etiqueta NORMAL dentro. Ahora campos y bordes de marco parten del mismo borde de contenido.
+
+**Pendiente de verificación manual por el usuario**: alineación marco/campos, aspecto en tema oscuro, y filas mixtas NORMAL + SMALL (el campo SMALL ya no ocupa la columna de etiqueta).

--- a/openxava/ui8-modernization-bloque2b-thread.md
+++ b/openxava/ui8-modernization-bloque2b-thread.md
@@ -160,19 +160,35 @@ Tras revisar un pantallazo de Facturas con las nuevas etiquetas, se aplicaron 4 
 
 **Verificado manualmente por el usuario (2026-08-21)**: espaciados, alineación marco/campos, color y tamaño de etiquetas — todo correcto en ambos temas.
 
-## Problema pendiente: fila mixta NORMAL + SMALL (Vía pública en Invoice)
+## Problema: fila mixta NORMAL + SMALL (Vía pública en Invoice) — RESUELTO
 
 ### Descripción
-En Invoice, la fila que mezcla etiqueta NORMAL ("Vía pública") con campos SMALL ("Código postal", etc.) muestra un **espacio muy grande entre la etiqueta "Vía pública" y su campo**. Apareció tras el ajuste 4 de arriba (eliminar la celda de etiqueta vacía para SMALL/NO_LABEL).
+En Invoice, la fila que mezcla etiqueta NORMAL ("Vía pública") con campos SMALL ("Código postal", etc.) mostraba un **espacio muy grande entre la etiqueta "Vía pública" y su campo** tras eliminar la celda de etiqueta vacía para SMALL/NO_LABEL.
 
-### Causa probable
-En vistas `alignedByColumns` las celdas son `table-cell` dentro de una tabla (o tabla anónima): la primera columna es la de etiquetas y la segunda la de editores. Antes, el campo SMALL llevaba una celda de etiqueta vacía que ocupaba la columna 1, así que su editor caía en la columna 2, alineado con el editor del campo NORMAL. Ahora el editor wrapper del SMALL entra en la **columna 1** (etiquetas), y como su contenido es ancho, estira esa columna, empujando el editor de "Vía pública" lejos de su etiqueta.
+### Causa
+En la tabla compartida, si un campo SMALL/NO_LABEL iba en primer lugar sin celda de etiqueta, su wrapper se convertía en la primera celda y ensanchaba la columna de etiquetas, alejando el campo NORMAL de su etiqueta.
 
-### Posibles vías de arreglo (evaluar el lunes)
-- **Dar al editor SMALL `grid-column`/span de 2 columnas**: en la tabla de layout, el campo SMALL debería ocupar etiqueta+editor (colspan=2), no solo la columna de etiqueta. En HTML plano sería `colspan`; con divs `table-cell` quizá haya que forzar que el wrapper SMALL no sea `table-cell` sino `inline-block` en filas mixtas, o envolverlo para que cruce ambas columnas.
-- **Alternativa conservadora**: volver a emitir la celda de etiqueta vacía para SMALL solo cuando la vista es `alignedByColumns` (donde la columna de etiqueta tiene función estructural), manteniendo la eliminación para el caso común no alineado.
-- Inspeccionar el DOM generado de esa fila en Invoice antes de decidir.
+### Correcciones intermedias (revertidas)
+- Se probó separar cada fila en su propia tabla (`FrameLayout.newLine` cerrando y abriendo `ox-layout-detail`) en vistas no alineadas. Esto eliminó el espacio en Invoice con `defaultLabelFormat=SMALL`, pero **rompió la alineación de campos NORMAL** (`Codigito`, `Tipo`, `Nombre`, `Foto`) porque ya no compartían la columna de etiquetas.
 
-### Archivos tocados por el ajuste 4 (origen del problema)
-- `src/main/java/org/openxava/web/render/PropertyEditorRenderer.java` (líneas 59-67)
-- `src/main/java/org/openxava/web/render/ReferenceRenderer.java` (líneas 75-91)
+### Solución final
+- Se mantiene **una sola tabla** para todo el detalle, de modo que la columna de etiquetas se comparte y los campos NORMAL se alinean.
+- `PropertyEditorRenderer.java` y `ReferenceRenderer.java` vuelven a emitir `preLabel`/`postLabel` vacíos para campos/referencias `SMALL`/`NO_LABEL` cuando son el **primer miembro de la fila** o la vista es `alignedByColumns`.
+- `layout.css` añade `.ox-layout-aligned-cell.ox-label:empty { padding: 0; }` para que esas celdas vacías no añadan el `padding-right: 8px` de `.ox-label` y desplacen el contenido de los marcos.
+- Se revierte `FrameLayout.newLine` (eliminado) y `DetailViewRenderer` vuelve a `<div class='ox-layout-new-line'></div>`.
+
+### Resultado
+- `defaultLabelFormat=SMALL`: Invoice se ve correcto, sin espacio excesivo en "Vía pública".
+- `defaultLabelFormat=NORMAL`: los campos de la primera fila vuelven a alinearse.
+- Los marcos con campos SMALL/NO_LABEL no se desplazan.
+- Verificado manualmente por el usuario (2026-08-24) para ambos formatos.
+
+## Archivos modificados finalmente
+
+| Archivo | Cambios |
+|---------|---------|
+| `src/main/java/org/openxava/web/render/PropertyEditorRenderer.java` | Emite celda de etiqueta vacía para `SMALL`/`NO_LABEL` cuando es el primero de la fila o `alignedByColumns` |
+| `src/main/java/org/openxava/web/render/ReferenceRenderer.java` | Idem para referencias |
+| `src/main/resources/META-INF/resources/xava/style/layout.css` | Añade `.ox-layout-aligned-cell.ox-label:empty { padding: 0; }` |
+| `src/main/java/org/openxava/web/render/FrameLayout.java` | Revertido: eliminado `newLine` |
+| `src/main/java/org/openxava/web/render/DetailViewRenderer.java` | Vuelve a `<div class='ox-layout-new-line'></div>` |

--- a/openxava/ui8-modernization-bloque2b-thread.md
+++ b/openxava/ui8-modernization-bloque2b-thread.md
@@ -102,6 +102,35 @@ El wrapper del booleano tiene esta estructura:
 - **Usar `vertical-align: top` en `.ox-small-label-wrapper` sin `inline-flex`**: Si `.xava_editor` vuelve a ser `inline` normal, el `vertical-align: top` del wrapper podría alinear todo desde arriba correctamente, y el `min-height` alone podría ser suficiente.
 - **Inspeccionar en el navegador**: Comparar las baselines exactas del wrapper del booleano vs el de un input de texto para entender el desfío en píxeles.
 
+## Resolución
+
+El problema de alineación se resolvió aplicando la misma baseline de 38px a **todos** los `.xava_editor` dentro de `.ox-editor-wrapper`, no solo a los de `.ox-small-label-wrapper`, y ajustando el `::before` para que la línea base quede en el centro del texto del input (25px) en lugar del borde inferior del contenido (29px).
+
+### CSS final (base.css)
+
+```css
+.ox-editor-wrapper .xava_editor {
+    display: inline-flex;
+    align-items: center;
+    min-height: 38px;
+}
+
+.ox-editor-wrapper .xava_editor::before {
+    content: "";
+    width: 0;
+    height: calc(20px + (var(--space-2) / 2) + 1px); /* 25px */
+    align-self: baseline;
+}
+```
+
+### Resultado
+- La etiqueta del booleano "Pagada" queda perfectamente alineada.
+- Acciones como "Cambiar nombre de etiqueta" y "Prefix street" se centran verticalmente con su campo.
+- Campos NO_LABEL como "Población" se alinean con campos SMALL como "Estado".
+- Campos NORMAL como "Vía pública" y "Código postal" se alinean con SMALL en la misma fila.
+- No se usa `.ox-switch` en la regla; es una solución genérica para editores pequeños (boolean, radio, etc.).
+- Verificado manualmente por el usuario: todo en su sitio.
+
 ## Archivos modificados en esta sesión
 
 | Archivo | Cambios |

--- a/openxava/ui8-modernization-bloque2b-thread.md
+++ b/openxava/ui8-modernization-bloque2b-thread.md
@@ -1,0 +1,121 @@
+# UI8 Modernization - Bloque 2b: Label Styles
+
+## Objetivo
+Modernizar el estilo de las etiquetas en OpenXava 8.0, haciendo que el formato `SMALL` (etiquetas arriba del campo) sea el formato por defecto, con una apariencia moderna y profesional acorde a 2026.
+
+## Cambios realizados y confirmados (ya en push)
+
+### 1. Default label format cambiado a SMALL
+- **Archivo**: `src/main/java/org/openxava/util/XavaPreferences.java` (líneas 344-345)
+- **Cambio**: `defaultLabelFormat` cambiado de `"NORMAL"` a `"SMALL"`
+- **También en**: `openxavatest/src/main/resources/xava.properties` (línea 61) — cambiado por el usuario
+
+### 2. CSS de `.small-label` modernizado
+- **Archivo**: `src/main/resources/META-INF/resources/xava/style/base.css` (líneas 2418-2427)
+- **Cambio actual**:
+  ```css
+  .small-label {
+      display: block;
+      padding-left: 0;
+      margin-top: var(--space-3);   /* 12px - separa del campo de arriba */
+      margin-bottom: var(--space-1); /* 4px - pega al campo de abajo */
+      font-size: var(--font-size-sm); /* 12px */
+      font-weight: 500;
+      color: var(--label-color);
+      line-height: 1.3;
+  }
+  ```
+
+### 3. Eliminado `<br/>` después del SMALL label
+- **Archivos**: `PropertyEditorRenderer.java` (línea 70) y `ReferenceRenderer.java` (línea 86)
+- **Cambio**: `w.append("</span><br/>")` → `w.append("</span>")`
+- **Razón**: Con `display: block` en `.small-label`, el `<br/>` añadía una línea vacía extra entre la etiqueta y el campo, alejándolos.
+
+### 4. Clase `ox-small-label-wrapper` en los renderers
+- **Archivos**: `PropertyEditorRenderer.java` (líneas 54-56) y `ReferenceRenderer.java` (líneas 70-72)
+- **Cambio**: Al construir `preEditor`, si el labelFormat es SMALL, se añade la clase `ox-small-label-wrapper`:
+  ```java
+  if (labelFormat == MetaPropertyView.SMALL_LABEL) {
+      preEditor = preEditor.replace("ox-editor-wrapper'", "ox-editor-wrapper ox-small-label-wrapper'");
+  }
+  ```
+- **Nota**: Esta clase ya existía en el código antes de esta sesión. Se usa para identificar los wrappers que contienen etiquetas SMALL.
+
+### 5. `min-height` e `inline-flex` en `.xava_editor`
+- **Archivo**: `src/main/resources/META-INF/resources/xava/style/base.css` (líneas 848-852)
+- **Cambio actual**:
+  ```css
+  .xava_editor {
+      min-height: 38px;
+      display: inline-flex;
+      align-items: center;
+  }
+  ```
+- **Razón**: Solución genérica para que editores pequeños (switch booleano, radio buttons, etc.) ocupen el mismo espacio vertical que un input de texto (38px) y se centren verticalmente. Esto hace que las etiquetas SMALL de campos pequeños se alineen con las de campos normales.
+
+### 6. `vertical-align: top` en `.ox-small-label-wrapper`
+- **Archivo**: `src/main/resources/META-INF/resources/xava/style/base.css` (líneas 1016-1018)
+- **Cambio actual**:
+  ```css
+  .ox-editor-wrapper.ox-small-label-wrapper {
+      vertical-align: top;
+  }
+  ```
+- **Estado**: NO funciona — la etiqueta del booleano sigue ligeramente desplazada.
+
+## Problema pendiente: Alineación de la etiqueta del booleano
+
+### Descripción
+La etiqueta "Pagada" (campo booleano con switch) queda ligeramente desplazada (un par de píxeles) respecto a las demás etiquetas SMALL ("Año", "Número", "Fecha", "Cantidad líneas").
+
+### Lo que se ha intentado
+1. **`vertical-align: top` en todas las celdas del layout** (`layout.css`): Rompió la alineación de etiquetas NORMAL, acciones y campos NO_LABEL. Revertido.
+2. **`:has(.ox-switch)` en `.ox-editor-wrapper`**: Funcionó para alinear la etiqueta pero el switch quedaba alineado arriba, no centrado. Revertido por solución a piñón fijo.
+3. **`min-height: 38px` + `inline-flex` + `align-items: center` en `.xava_editor`**: Solución genérica. El switch se centra bien, pero la etiqueta queda ligeramente desplazada (un par de píxeles).
+4. **`vertical-align: top` en `.ox-small-label-wrapper`**: Añadido encima del `min-height`, pero no resuelve el desfío. **Sigue sin funcionar.**
+5. **Ajustar `margin-top` de `.small-label`**: Cambia todas las etiquetas a la vez, no solo la del booleano.
+6. **Ajustar `padding-top` de `.ox-editor-wrapper`**: Igual, cambia todas a la vez.
+7. **Ajustar `min-height` de `.xava_editor`**: Valores menores a 38px bajan la etiqueta (la alejan). Valores mayores a 38px no tienen efecto (los inputs de texto ya miden 38px).
+
+### Análisis del problema
+- El layout usa `display: table` con celdas `table-cell` o `inline-block`.
+- Los wrappers se alinean por `vertical-align: baseline` por defecto.
+- Con `inline-flex` en `.xava_editor`, la baseline del flex container cambia respecto a la de un input de texto normal.
+- El switch (24px) centrado en un `min-height: 38px` produce una baseline diferente a la de un input de texto (38px reales).
+- Ese desfío de baseline arrastra la etiqueta SMALL del booleano un par de píxeles.
+
+### HTML de referencia
+El wrapper del booleano tiene esta estructura:
+```html
+<div class="ox-layout-not-aligned-cell ox-editor-wrapper ox-small-label-wrapper">
+  <span class="small-label">Pagada</span>
+  <span class="xava_editor">
+    <input type="checkbox" class="editor ox-switch" ...>
+  </span>
+  <span id="..._property_actions_paid"></span>
+</div>
+```
+
+### Posibles siguientes pasos a explorar
+- **`vertical-align: top` en `.ox-small-label-wrapper` combinado con quitar `inline-flex` de `.xava_editor`**: Quizás el problema es que `inline-flex` cambia la baseline. Probar con `display: inline-block` + `line-height: 38px` en `.xava_editor` en lugar de `inline-flex`.
+- **Alinear el switch con `margin-top` negativo dentro del flex**: Ajustar fino el `margin-top` del `input.ox-switch` dentro del flex container.
+- **Usar `vertical-align: top` en `.ox-small-label-wrapper` sin `inline-flex`**: Si `.xava_editor` vuelve a ser `inline` normal, el `vertical-align: top` del wrapper podría alinear todo desde arriba correctamente, y el `min-height` alone podría ser suficiente.
+- **Inspeccionar en el navegador**: Comparar las baselines exactas del wrapper del booleano vs el de un input de texto para entender el desfío en píxeles.
+
+## Archivos modificados en esta sesión
+
+| Archivo | Cambios |
+|---------|---------|
+| `src/main/java/org/openxava/util/XavaPreferences.java` | defaultLabelFormat: NORMAL → SMALL |
+| `src/main/resources/META-INF/resources/xava/style/base.css` | `.small-label` modernizado, `<br/>` eliminado (via Java), `.xava_editor` con min-height+inline-flex, `.ox-small-label-wrapper` con vertical-align:top |
+| `src/main/java/org/openxava/web/render/PropertyEditorRenderer.java` | `<br/>` eliminado, `ox-small-label-wrapper` ya existía |
+| `src/main/java/org/openxava/web/render/ReferenceRenderer.java` | `<br/>` eliminado, `ox-small-label-wrapper` ya existía |
+| `src/main/resources/META-INF/resources/xava/style/layout.css` | Sin cambios (revertido) |
+| `openxavatest/src/main/resources/xava.properties` | defaultLabelFormat=SMALL (cambiado por el usuario) |
+
+## Notas
+- La versión de OpenXava es 8.0.
+- El usuario prefiere testing manual desde el IDE.
+- El usuario hizo un push con los cambios confirmados (puntos 1-4) antes de seguir con el problema del booleano.
+- Los puntos 5 y 6 (min-height + vertical-align:top) están en el código pero NO resuelven completamente el problema del booleano.
+- Hay que decidir si mantener los puntos 5 y 6 o revertirlos si no se encuentra solución.

--- a/openxava/ui8-modernization-bloque2b-thread.md
+++ b/openxava/ui8-modernization-bloque2b-thread.md
@@ -158,4 +158,21 @@ Tras revisar un pantallazo de Facturas con las nuevas etiquetas, se aplicaron 4 
 3. **Etiquetas con más contraste en tema oscuro**: `--label-color` de `#d4d4d8` a `#e4e4e7` (zinc-300 → zinc-200) en dark-overrides.css.
 4. **Marcos alineados con los campos**: causa raíz — para etiquetas SMALL/NO_LABEL se emitía un `<div class='ox-layout-...-cell ox-label'>` **vacío** antes del campo; al ser `table-cell` (primera celda de fila) generaba una tabla anónima con border-spacing + whitespace (~8px) que desplazaba los campos a la derecha del borde del marco. Fix en `PropertyEditorRenderer.java` y `ReferenceRenderer.java`: la celda de etiqueta (`preLabel`/`postLabel`) solo se emite cuando hay etiqueta NORMAL dentro. Ahora campos y bordes de marco parten del mismo borde de contenido.
 
-**Pendiente de verificación manual por el usuario**: alineación marco/campos, aspecto en tema oscuro, y filas mixtas NORMAL + SMALL (el campo SMALL ya no ocupa la columna de etiqueta).
+**Verificado manualmente por el usuario (2026-08-21)**: espaciados, alineación marco/campos, color y tamaño de etiquetas — todo correcto en ambos temas.
+
+## Problema pendiente: fila mixta NORMAL + SMALL (Vía pública en Invoice)
+
+### Descripción
+En Invoice, la fila que mezcla etiqueta NORMAL ("Vía pública") con campos SMALL ("Código postal", etc.) muestra un **espacio muy grande entre la etiqueta "Vía pública" y su campo**. Apareció tras el ajuste 4 de arriba (eliminar la celda de etiqueta vacía para SMALL/NO_LABEL).
+
+### Causa probable
+En vistas `alignedByColumns` las celdas son `table-cell` dentro de una tabla (o tabla anónima): la primera columna es la de etiquetas y la segunda la de editores. Antes, el campo SMALL llevaba una celda de etiqueta vacía que ocupaba la columna 1, así que su editor caía en la columna 2, alineado con el editor del campo NORMAL. Ahora el editor wrapper del SMALL entra en la **columna 1** (etiquetas), y como su contenido es ancho, estira esa columna, empujando el editor de "Vía pública" lejos de su etiqueta.
+
+### Posibles vías de arreglo (evaluar el lunes)
+- **Dar al editor SMALL `grid-column`/span de 2 columnas**: en la tabla de layout, el campo SMALL debería ocupar etiqueta+editor (colspan=2), no solo la columna de etiqueta. En HTML plano sería `colspan`; con divs `table-cell` quizá haya que forzar que el wrapper SMALL no sea `table-cell` sino `inline-block` en filas mixtas, o envolverlo para que cruce ambas columnas.
+- **Alternativa conservadora**: volver a emitir la celda de etiqueta vacía para SMALL solo cuando la vista es `alignedByColumns` (donde la columna de etiqueta tiene función estructural), manteniendo la eliminación para el caso común no alineado.
+- Inspeccionar el DOM generado de esa fila en Invoice antes de decidir.
+
+### Archivos tocados por el ajuste 4 (origen del problema)
+- `src/main/java/org/openxava/web/render/PropertyEditorRenderer.java` (líneas 59-67)
+- `src/main/java/org/openxava/web/render/ReferenceRenderer.java` (líneas 75-91)

--- a/openxava/ui8-modernization-plan.md
+++ b/openxava/ui8-modernization-plan.md
@@ -62,8 +62,9 @@ Dividido en 4 sub-bloques con rama propia cada uno. Cada sub-bloque se prueba, r
 - [x] Modernize textfield look&feel (1px border, radius-md, 38px de alto, hover, anillo de foco con acento, disabled suave, selects con chevron propio, tabular-nums en numéricos).
 - [x] Mark with * required field (asterisco rojo vía `ox-required-label` en `PropertyEditorRenderer` y `ReferenceRenderer`; el borde distintivo se neutraliza a `--input-border`).
 - [x] Switch editor for booleans (CSS puro sobre el checkbox dentro de `.xava_editor`, con tokens `--switch-*`).
+- [x] Labels on top by default (`defaultLabelFormat` cambiado de `NORMAL` a `SMALL` en `XavaPreferences`; CSS de `.small-label` modernizado; `<br/>` eliminado en `PropertyEditorRenderer` y `ReferenceRenderer`; alineación de etiquetas SMALL con campos pequeños y mixtos resuelta; marcos alineados con campos).
 
-Pendiente de revisión visual manual antes de fusionar: detalle, colecciones, diálogos, calendario, modo phone, en los 3 temas.
+**Concluido.** Tests pasados, estética revisada en los 3 temas (Auto/Light/Dark) y modo phone.
 
 ### Bloque 2c — Popups (`ui-popups`)
 

--- a/openxava/ui8-modernization-plan.md
+++ b/openxava/ui8-modernization-plan.md
@@ -59,9 +59,11 @@ Dividido en 4 sub-bloques con rama propia cada uno. Cada sub-bloque se prueba, r
 
 ### Bloque 2b — Campos (`ui-fields`)
 
-- [ ] Modernize textfield look&feel.
-- [ ] Mark with * required field.
-- [ ] Switch editor for booleans.
+- [x] Modernize textfield look&feel (1px border, radius-md, 38px de alto, hover, anillo de foco con acento, disabled suave, selects con chevron propio, tabular-nums en numéricos).
+- [x] Mark with * required field (asterisco rojo vía `ox-required-label` en `PropertyEditorRenderer` y `ReferenceRenderer`; el borde distintivo se neutraliza a `--input-border`).
+- [x] Switch editor for booleans (CSS puro sobre el checkbox dentro de `.xava_editor`, con tokens `--switch-*`).
+
+Pendiente de revisión visual manual antes de fusionar: detalle, colecciones, diálogos, calendario, modo phone, en los 3 temas.
 
 ### Bloque 2c — Popups (`ui-popups`)
 

--- a/openxavatest/manual-tests/StyleTest.txt
+++ b/openxavatest/manual-tests/StyleTest.txt
@@ -6,13 +6,7 @@ with Terra and Light theme at least the next cases:
 		(It fails currently: https://openxava.org/xavaprojects/o/OpenXava/m/Issue?detail=ff8080818de6fbe7018dea720e5e0007)
 	- Dates for "Date as label" column are shown completely.
 	- Narrow the browser, the content of type and description columns are not overlapped between rows.  
-- Invoice: Go to first detail. 
-	- Checkbox of paid must be well aligned.
-	- Action links in name of customer and street of address must be well aligned.
-	- The editors for street (with regular label) and postal code (with small label) must be well aligned.
-	- The editors for city (no label) and state (small label) must be well aligned.
-	- The label of photo must be well aligned (top or middle but not ugly).
-- ProjectMember with Dark:	
+- ProjectMember with Dark:
 	- Go to first detail.
 	- Click to edit the project, so a dialog is shown.
 	- Dialog data is readable, white over black, instead of black over black.
@@ -27,5 +21,20 @@ with Terra and Light theme at least the next cases:
 	- Links for page numbers and 'Hide records' links are visible.
 - Product2:
 	- Open a descriptions list combo, the background is white.	
-		
+- Invoice:
+    - Go to first detail.
+	- Paid label aligned with other labels and paid editor centered with other fields.
+	- Action links in name of customer and street of address must be well aligned.
+	- The editors for street (with regular label) and postal code (with small label) must be well aligned.
+	- The editors for city (no label) and state (small label) must be well aligned.
+	- Year field aligned on left with Discounts frame.
+- Invoice: With defaultLabelFormat=NORMAL
+    - Go to first detail.
+    - Paid editor must be well aligned.
+    - Action links in name of customer and street of address must be well aligned.
+    - The editors for street (with regular label) and postal code (with small label) must be well aligned.
+    - The editors for city (no label) and state (small label) must be well aligned.
+    - The label of photo must be well aligned (top or middle but not ugly).
+    - The 4 fields inside Customer before Address should be aligned.
+
 

--- a/openxavatest/src/main/resources/xava.properties
+++ b/openxavatest/src/main/resources/xava.properties
@@ -58,7 +58,7 @@ reportParametersProviderClass=org.openxava.test.util.MyReportParametersProvider
 #defaultModeController=Mode
 
 # Possibles values for defaultLabelFormat are: NORMAL, SMALL and NO_LABEL
-defaultLabelFormat=NORMAL
+defaultLabelFormat=SMALL
 # It has defined: bold-label, italic-label. And you can define your own style.
 #defaultLabelStyle=bold-label
 

--- a/openxavatest/src/main/resources/xava.properties
+++ b/openxavatest/src/main/resources/xava.properties
@@ -58,7 +58,7 @@ reportParametersProviderClass=org.openxava.test.util.MyReportParametersProvider
 #defaultModeController=Mode
 
 # Possibles values for defaultLabelFormat are: NORMAL, SMALL and NO_LABEL
-defaultLabelFormat=SMALL
+defaultLabelFormat=NORMAL
 # It has defined: bold-label, italic-label. And you can define your own style.
 #defaultLabelStyle=bold-label
 


### PR DESCRIPTION
- Default value for defaultLabelFormat in xava.properties changed from NORMAL to SMALL, so property labels are now displayed in small format by default.
- Text fields, selects and textareas redesigned: 1px border, 8px corner radius, taller and more comfortable (38px), hover border, accent focus ring and softer disabled state.
- Required properties and references are now marked with a red asterisk next to the label, instead of a darker field border.
- Boolean properties in detail view use a modern switch (toggle) editor instead of a checkbox.
- Property labels use medium font weight and a softer color for a cleaner, less noisy look.
- Numeric fields use tabular-nums so digits align when comparing values.
- New CSS variables for field customization: --input-hover-border, --placeholder-color, --disabled-input-color, --label-color, --required-indicator-color, --select-chevron-icon, --switch-off-background, --switch-off-hover-background, --switch-on-background, --switch-on-hover-background, --switch-knob-background.
