### PR TITLE
Don't include non-existing flatpick en.js resource file.

### DIFF
--- a/openxava/src/main/resources/META-INF/resources/xava/editors/js/dateCalendarEditor.js
+++ b/openxava/src/main/resources/META-INF/resources/xava/editors/js/dateCalendarEditor.js
@@ -2,7 +2,9 @@
 if (dateCalendarEditor == null) var dateCalendarEditor = {};
 
 openxava.addEditorInitFunction(function() {
-    openxava.getScript(openxava.contextPath + "/xava/editors/flatpickr/" + openxava.language + ".js");
+    if (openxava.language !== 'en') {
+      openxava.getScript(openxava.contextPath + "/xava/editors/flatpickr/" + openxava.language + ".js");
+    }
     if (openxava.browser.htmlUnit) return;
     dateCalendarEditor.readInput = false;
     dateCalendarEditor.enterDate;

--- a/openxava/src/main/resources/META-INF/resources/xava/editors/js/timeCalendarEditor.js
+++ b/openxava/src/main/resources/META-INF/resources/xava/editors/js/timeCalendarEditor.js
@@ -2,7 +2,9 @@
 if (timeCalendarEditor == null) var timeCalendarEditor = {};
 
 openxava.addEditorInitFunction(function() {
-    openxava.getScript(openxava.contextPath + "/xava/editors/flatpickr/" + openxava.language + ".js");
+    if (openxava.language !== 'en') {
+      openxava.getScript(openxava.contextPath + "/xava/editors/flatpickr/" + openxava.language + ".js");
+    }
     if (openxava.browser.htmlUnit) return;
 
     timeCalendarEditor.onOpenDateTime;


### PR DESCRIPTION
flatpickr main js file already includes english resources and there is no separate en.js file

That avoids 404 error when loading any view having date element and using english UI language.

Testing manually with en + de languages the flatpickr element still shows local language.

Running the DateCalendarTest shows no errors (especially testMultipleDateWithOnChange_localeTranslationWellLoaded covers this)

https://openxava.org/xavaprojects/o/OpenXava/m/Issue?detail=2c9e8323a01080e001a0764b4dcd0087